### PR TITLE
Corrige login-wizard

### DIFF
--- a/components/login-wizard/script.js
+++ b/components/login-wizard/script.js
@@ -88,7 +88,6 @@ app.component('login-wizard', {
             };
     
             return await api.POST($MAPAS.baseURL + "autenticacao/verify", dataPost).then(response => response.json().then(dataReturn => {
-                console.log(dataReturn.result)
                 if (dataReturn.error) {
                     this.throwErrors(dataReturn.data);
                 } else {
@@ -189,7 +188,7 @@ app.component('login-wizard', {
         throwErrors(errors) {
             const messages = useMessages();
 
-            if (this.recaptchaResponse !== '') {
+            if (this.recaptchaShown && this.recaptchaResponse !== '') {
                 grecaptcha.reset();
                 this.expiredCaptcha();
             }

--- a/components/login-wizard/template.php
+++ b/components/login-wizard/template.php
@@ -55,7 +55,7 @@ $this->import('
 
                     <div class="login__buttons">
                         <button v-if="!showPassword && !passwordResetRequired && !userNotFound" class="button button--primary button--large button--md" type="submit"> <?= i::__('Próximo') ?> </button>
-                        <button v-if="showPassword && !passwordResetRequired" class="button button--primary button--large button--md" type="button" @click="doLogin"> <?= i::__('Entrar') ?> </button>
+                        <button v-if="showPassword && !passwordResetRequired" class="button button--primary button--large button--md" type="submit" @click="doLogin"> <?= i::__('Entrar') ?> </button>
                         <button v-if="passwordResetRequired" class="button button--primary button--large button--md" @click="recoveryRequest = true"> <?= i::__('Gerar nova senha') ?> </button>
                         <button  v-if="passwordResetRequired || showPassword" class="button button--secondary button--large button--md" @click="resetLoginState"> <?= i::__('Voltar') ?> </button>
                     </div>

--- a/views/auth/multiple-local.php
+++ b/views/auth/multiple-local.php
@@ -12,24 +12,15 @@ if (trim($_GET['t'] ?? '')) {
     $this->jsObject['recoveryMode']['token'] = $_GET['t']; 
 }
 
-$flag = 'login';
-
-$templates = [
-    'login' => function () use ($configs) {
-        return "<login config='$configs'></login>";
-    },
-
-    'login-wizard' => function () use ($configs) {
-        return "<login-wizard config='$configs'></login-wizard>";
+$loginMode = 'login';
+if (isset($config['wizard'])) {
+    if ($config['wizard'] == 'true') {
+        $loginMode = 'login-wizard';
     }
-];
-
-if ($config['wizard'] == true){
-    $flag = 'login-wizard';
 }
 
-$this->import($flag);
+$this->import($loginMode);
 
-echo $templates[$flag]();
+echo "<$loginMode config='$configs'></$loginMode>"
+
 ?>
-


### PR DESCRIPTION
Correções no login-wizard
* Exibir as mensagens de erro ou alerta para orientar as pessoas durante o acesso.
* Tornar padrão o botão "Entrar" quando a pessoa pressionar ENTER na digitação da senha.
* Reescreve trecho de código para melhorar a compreensão do arquivo [views/auth/multiple-local.php](https://github.com/culturagovbr/MultipleLocalAuth/compare/feature/login-basev2...correcao-5322-etapa1#diff-37fd24f25ad5fde78c49141e32bba5d3b440140fab84b074dd1cce9b6d68474e)