### PR TITLE
feat: implementando o hook responsável - entre outras coisas - por atualizar a data de último login

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -335,6 +335,9 @@ class Provider extends \MapasCulturais\AuthProvider {
             $login = $app->auth->doLogin();
 
             if ($login['success']) {
+                // Chamando Hook do Mapa, responsável por registrar o último login
+                App::i()->applyHook('auth.successful');
+
                 $this->json([
                     'error' => false, 
                     'redirectTo' => $app->auth->getRedirectPath()


### PR DESCRIPTION
Prezados,
ao debugar o Core do Mapa da Cultura, percebi que o o Plugin está reescrevendo alguns comportamentos do Mapa da Cultura e que faltou a implementação do hook responsável por registrar a data do último login